### PR TITLE
Fix: Limit Preview instances to live for 2 days

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -22,3 +22,4 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_TERCUMAN_BULMACA }}"
           projectId: tercuman-bulmaca
+          expires: 2d


### PR DESCRIPTION
We have filled our firebase hosting with 50 containers :D 

Follow-up I have just thought of while writing this: Might be a good idea to not restrict the expiration, but delete on PR merge.